### PR TITLE
[FIX]Multi company

### DIFF
--- a/helpdesk/data/helpdesk_data.xml
+++ b/helpdesk/data/helpdesk_data.xml
@@ -28,6 +28,7 @@
       <field name="code">helpdesk.ticket.sequence</field>
       <field name="prefix">HT</field>
       <field name="padding">5</field>
+      <field name="company_id" eval="False"/>
     </record>
     <!-- Stages -->
     <record id="helpdesk_ticket_stage_new" model="helpdesk.ticket.stage">
@@ -35,18 +36,22 @@
       <field name="name">New</field>
       <field name="unattended">True</field>
       <field name="closed">False</field>
+      <field name="company_id"></field>
+
     </record>
     <record id="helpdesk_ticket_stage_in_progress" model="helpdesk.ticket.stage">
       <field name="sequence">2</field>
       <field name="name">In Progress</field>
       <field name="unattended">False</field>
       <field name="closed">False</field>
+      <field name="company_id"></field>
     </record>
     <record id="helpdesk_ticket_stage_awaiting" model="helpdesk.ticket.stage">
       <field name="sequence">3</field>
       <field name="name">Awaiting</field>
       <field name="unattended">False</field>
       <field name="closed">False</field>
+      <field name="company_id"></field>
     </record>
     <record id="helpdesk_ticket_stage_done" model="helpdesk.ticket.stage">
       <field name="sequence">3</field>
@@ -54,6 +59,7 @@
       <field name="unattended">False</field>
       <field name="closed">True</field>
       <field name="fold">True</field>
+      <field name="company_id"></field>
     </record>
     <record id="helpdesk_ticket_stage_cancelled" model="helpdesk.ticket.stage">
       <field name="sequence">4</field>
@@ -61,6 +67,7 @@
       <field name="unattended">False</field>
       <field name="closed">True</field>
       <field name="fold">True</field>
+      <field name="company_id"></field>
     </record>
     <!-- Channels -->
     <record id="helpdesk_ticket_channel_web" model="helpdesk.ticket.channel">

--- a/helpdesk/models/helpdesk_ticket.py
+++ b/helpdesk/models/helpdesk_ticket.py
@@ -111,9 +111,15 @@ class HelpdeskTicket(models.Model):
     @api.model
     def create(self, vals):
         if vals.get('number', '/') == '/':
-            vals['number'] = self.env['ir.sequence'].next_by_code(
-                'helpdesk.ticket.sequence'
-            ) or '/'
+            if 'company_id' in vals:
+                vals['number'] = self.env['ir.sequence'].with_context(
+                    force_company=vals['company_id']).next_by_code(
+                    'helpdesk.ticket.sequence'
+                ) or '/'
+            else:
+                vals['number'] = self.env['ir.sequence'].next_by_code(
+                    'helpdesk.ticket.sequence'
+                ) or '/'
         res = super().create(vals)
 
         # Check if mail to the user has to be sent

--- a/helpdesk/views/helpdesk_ticket_view.xml
+++ b/helpdesk/views/helpdesk_ticket_view.xml
@@ -80,7 +80,7 @@
                             <field name="user_id" options='{"always_reload": True}'/>
 
                             <field name="priority" widget="priority"/>
-                            <field name="company_id" readonly="1" groups="base.group_multi_company"/>
+                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             <field name="create_date"/>
                             <field name="channel_id"/>
                         </group>


### PR DESCRIPTION
1.- Added company_id field (empty) to the initial creation of stages (data folder). This allows to use the initial stages with multi-company, so they are not created with any company.

2.- Added company_id field to the sequence. The purpose of this is to make posible having different sequences in each company.

3.- Refactored the "create" method to make posible different sequences.

4.- Deleted "readonly" attribute of company_id in the helpdesk.ticket form.